### PR TITLE
Feature/deleted observer

### DIFF
--- a/src/Traits/Favoriteable.php
+++ b/src/Traits/Favoriteable.php
@@ -28,8 +28,6 @@ trait Favoriteable
     /**
      * Add this Object to the user favorites
      * 
-	 * 
-     * 
      * @param  int $user_id  [if  null its added to the auth user]
      */
     public function addFavorite($user_id = null)
@@ -43,8 +41,6 @@ trait Favoriteable
      *
      * @param  int $user_id  [if  null its added to the auth user]
      * 
-	 * 
-     * 
      */
     public function removeFavorite($user_id = null)
     {
@@ -53,8 +49,6 @@ trait Favoriteable
 
     /**
      * Toggle the favorite status from this Object
-     * 
-	 * 
      * 
      * @param  int $user_id  [if  null its added to the auth user]
      */
@@ -65,8 +59,6 @@ trait Favoriteable
 
     /**
      * Check if the user has favorited this Object
-     * 
-	 * 
      * 
      * @param  int $user_id  [if  null its added to the auth user]
      * @return boolean
@@ -91,8 +83,6 @@ trait Favoriteable
     /**
      * Count the number of favorites
      * 
-	 * 
-     * 
      * @return int
      */
     public function getFavoritesCountAttribute()
@@ -106,6 +96,20 @@ trait Favoriteable
     public function favoritesCount()
     {
         return $this->favoritesCount;
+    }
+
+    /**
+     * Add deleted observer to delete favorites registers
+     * 
+     * @return void
+     */
+    public static function bootFavoriteable()
+    {
+        static::deleted(
+            function ($model) {
+                $model->favorites()->delete();
+            }
+        );
     }
 
 }

--- a/src/Traits/Favoriteable.php
+++ b/src/Traits/Favoriteable.php
@@ -15,86 +15,97 @@ use Illuminate\Support\Facades\Auth;
  */
 trait Favoriteable
 {
-	/**
+    /**
      * Define a polymorphic one-to-many relationship.
      *
      * @return \Illuminate\Database\Eloquent\Relations\MorphMany
      */
-	public function favorites()
-	{
-		return $this->morphMany(Favorite::class, 'favoriteable');
-	}
+    public function favorites()
+    {
+        return $this->morphMany(Favorite::class, 'favoriteable');
+    }
 
-	/**
-	 * Add this Object to the user favorites
+    /**
+     * Add this Object to the user favorites
+     * 
 	 * 
-	 * @param  int $user_id  [if  null its added to the auth user]
-	 */
-	public function addFavorite($user_id = null)
-	{
-		$favorite = new Favorite(['user_id' => ($user_id) ? $user_id : Auth::id()]);
-		$this->favorites()->save($favorite);
-	}
+     * 
+     * @param  int $user_id  [if  null its added to the auth user]
+     */
+    public function addFavorite($user_id = null)
+    {
+        $favorite = new Favorite(['user_id' => ($user_id) ? $user_id : Auth::id()]);
+        $this->favorites()->save($favorite);
+    }
 
-	/**
-	 * Remove this Object from the user favorites
-	 *
-	 * @param  int $user_id  [if  null its added to the auth user]
+    /**
+     * Remove this Object from the user favorites
+     *
+     * @param  int $user_id  [if  null its added to the auth user]
+     * 
 	 * 
-	 */
-	public function removeFavorite($user_id = null)
-	{
-		$this->favorites()->where('user_id', ($user_id) ? $user_id : Auth::id())->delete();
-	}
+     * 
+     */
+    public function removeFavorite($user_id = null)
+    {
+        $this->favorites()->where('user_id', ($user_id) ? $user_id : Auth::id())->delete();
+    }
 
-	/**
-	 * Toggle the favorite status from this Object
+    /**
+     * Toggle the favorite status from this Object
+     * 
 	 * 
-	 * @param  int $user_id  [if  null its added to the auth user]
-	 */
-	public function toggleFavorite($user_id = null)
-	{
-		$this->isFavorited($user_id) ? $this->removeFavorite($user_id) : $this->addFavorite($user_id) ;
-	}
+     * 
+     * @param  int $user_id  [if  null its added to the auth user]
+     */
+    public function toggleFavorite($user_id = null)
+    {
+        $this->isFavorited($user_id) ? $this->removeFavorite($user_id) : $this->addFavorite($user_id) ;
+    }
 
-	/**
-	 * Check if the user has favorited this Object
+    /**
+     * Check if the user has favorited this Object
+     * 
 	 * 
-	 * @param  int $user_id  [if  null its added to the auth user]
-	 * @return boolean
-	 */
-	public function isFavorited($user_id = null)
-	{
-		return $this->favorites()->where('user_id', ($user_id) ? $user_id : Auth::id())->exists();
-	}
+     * 
+     * @param  int $user_id  [if  null its added to the auth user]
+     * @return boolean
+     */
+    public function isFavorited($user_id = null)
+    {
+        return $this->favorites()->where('user_id', ($user_id) ? $user_id : Auth::id())->exists();
+    }
 
-	/**
+    /**
      * Return a collection with the Users who marked as favorite this Object.
      * 
      * @return Collection
      */
-	public function favoritedBy()
-	{
-		return $this->favorites()->with('user')->get()->mapWithKeys(function ($item) {
+    public function favoritedBy()
+    {
+        return $this->favorites()->with('user')->get()->mapWithKeys(function ($item) {
             return [$item['user']->id => $item['user']];
         });
-	}
+    }
 
-	/**
-	 * Count the number of favorites
+    /**
+     * Count the number of favorites
+     * 
 	 * 
-	 * @return int
-	 */
-	public function getFavoritesCountAttribute()
-	{
-		return $this->favorites()->count();
-	}
+     * 
+     * @return int
+     */
+    public function getFavoritesCountAttribute()
+    {
+        return $this->favorites()->count();
+    }
 
-	/**
-	 * @return favoritesCount attribute
-	 */
-	public function favoritesCount()
-	{
-		return $this->favoritesCount;
-	}
+    /**
+     * @return favoritesCount attribute
+     */
+    public function favoritesCount()
+    {
+        return $this->favoritesCount;
+    }
+
 }

--- a/tests/FavoriteModelTest.php
+++ b/tests/FavoriteModelTest.php
@@ -221,4 +221,50 @@ class FavoriteModelTest extends TestCase
 
         $this->assertEquals(0, $article->favoritedBy()->count());
     }
+
+    /** @test */
+    public function a_model_delete_favorites_on_deleted_observer()
+    {
+        $user = User::find(1);
+        $user2 = User::find(2);
+
+        $article = Article::first();
+
+        $user->addFavorite($article);
+        $user2->addFavorite($article);
+
+        $this->assertDatabaseHas(
+            'favorites', [
+                'user_id' => $user->id,
+                'favoriteable_id' => $article->id,
+                'favoriteable_type' => get_class($article)
+            ]
+        );
+
+        $this->assertDatabaseHas(
+            'favorites', [
+                'user_id' => $user2->id,
+                'favoriteable_id' => $article->id,
+                'favoriteable_type' => get_class($article)
+            ]
+        );
+
+        $article->delete();
+
+        $this->assertDatabaseMissing(
+            'favorites', [
+                'user_id' => $user->id,
+                'favoriteable_id' => $article->id,
+                'favoriteable_type' => get_class($article)
+            ]
+        );
+
+        $this->assertDatabaseMissing(
+            'favorites', [
+                'user_id' => $user2->id,
+                'favoriteable_id' => $article->id,
+                'favoriteable_type' => get_class($article)
+            ]
+        );
+    }
 }


### PR DESCRIPTION
## Description

Add observer in favoriteable model to delete favorites when deleted.

## Motivation and context

If model favoriteable is favorited by a user and it is deleted it may cause exceptions in Favoriteability's methods as a `favorite(class_name)`

## How has this been tested?

added one article as a favorite for two users and deleted the article and see if the records have been deleted from favorites table.

## Types of changes

What types of changes does your code introduce?
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] I have read the **[CONTRIBUTING](CONTRIBUTING.md)** document.
- [x] My pull request addresses exactly one patch/feature.
- [x] I have created a branch for this patch/feature.
- [x] Each individual commit in the pull request is meaningful.
- [x] I have added tests to cover my changes.
- [x] If my change requires a change to the documentation, I have updated it accordingly.
